### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,7 +258,7 @@ pnpm update-outdated-deps
 
 We use [GitHub Actions](https://github.com/features/actions) for this repository.
 
-You can find the configuration in the [.github/workflows](.github/workflows/) folder and the build results are available [here](https://github.com/gsoft-inc/wl-squide/actions).
+You can find the configuration in the [.github/workflows](.github/workflows/) folder and the build results are available [here](https://github.com/workleap/wl-squide/actions).
 
 We currently have 3 builds configured:
 
@@ -272,6 +272,6 @@ This action will trigger when a commit is done in a PR to `main` or after a push
 
 ### Retype
 
-This action will trigger when a commit is done in a PR to `main` or after a push to `main`. The action will generate the documentation website into the `retype` branch. This repository [Github Pages](https://github.com/gsoft-inc/wl-web-configs/settings/pages) is configured to automatically deploy the website from the `retype` branch.
+This action will trigger when a commit is done in a PR to `main` or after a push to `main`. The action will generate the documentation website into the `retype` branch. This repository [Github Pages](https://github.com/workleap/wl-web-configs/settings/pages) is configured to automatically deploy the website from the `retype` branch.
 
 If you are having issue with the Retype license, make sure the `RETYPE_API_KEY` Github secret contains a valid Retype license.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To ask a question or propose an idea, feel free to start a new [discussion](http
 
 ## Documentation
 
-View the [user's documentation](https://gsoft-inc.github.io/wl-honeycomb-web).
+View the [user's documentation](https://workleap.github.io/wl-honeycomb-web).
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Default [Honeycomb](https://www.honeycomb.io/) instrumentation for [Workleap](https://workleap.com/) web applications.
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
-[![CI](https://github.com/gsoft-inc/wl-honeycomb-web/actions/workflows/ci.yml/badge.svg)](https://github.com/gsoft-inc/wl-honeycomb-web/actions/workflows/ci.yml)
+[![CI](https://github.com/workleap/wl-honeycomb-web/actions/workflows/ci.yml/badge.svg)](https://github.com/workleap/wl-honeycomb-web/actions/workflows/ci.yml)
 
 ### Packages
 
@@ -13,7 +13,7 @@ Default [Honeycomb](https://www.honeycomb.io/) instrumentation for [Workleap](ht
 
 ## Have a question or found an issue?
 
-To ask a question or propose an idea, feel free to start a new [discussion](https://github.com/gsoft-inc/wl-honeycomb-web/discussions). If you found a bug, please open an [issue](https://github.com/gsoft-inc/wl-honeycomb-web/issues).
+To ask a question or propose an idea, feel free to start a new [discussion](https://github.com/workleap/wl-honeycomb-web/discussions). If you found a bug, please open an [issue](https://github.com/workleap/wl-honeycomb-web/issues).
 
 ## Documentation
 
@@ -25,4 +25,4 @@ View the [contributor's documentation](./CONTRIBUTING.md).
 
 ## License
 
-Copyright © 2024, Workleap This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/workleap-license/blob/master/LICENSE.
+Copyright © 2024, Workleap This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/workleap-license/blob/master/LICENSE.

--- a/docs/about.md
+++ b/docs/about.md
@@ -4,12 +4,12 @@ layout: page
 
 # About
 
-To ask a question or propose an idea, feel free to start a new [discussion](https://github.com/gsoft-inc/wl-squide/discussions) on Github. If you found a bug, please open an [issue](https://github.com/gsoft-inc/wl-squide/issues) on Github.
+To ask a question or propose an idea, feel free to start a new [discussion](https://github.com/workleap/wl-squide/discussions) on Github. If you found a bug, please open an [issue](https://github.com/workleap/wl-squide/issues) on Github.
 
 ## Contributing
 
-Have a look at the [contributor's documentation](https://github.com/gsoft-inc/wl-squide/blob/main/CONTRIBUTING.md).
+Have a look at the [contributor's documentation](https://github.com/workleap/wl-squide/blob/main/CONTRIBUTING.md).
 
 ## License
 
-See the [LICENSE](https://github.com/gsoft-inc/wl-squide/blob/main/LICENSE) on Github.
+See the [LICENSE](https://github.com/workleap/wl-squide/blob/main/LICENSE) on Github.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,4 +150,4 @@ If you are experiencing issues with this guide:
 - Set the [debug](./reference/registerHoneycombInstrumentation.md#debug) predefined option to `true`.
 - Open the [DevTools](https://developer.chrome.com/docs/devtools/) console. You'll see a log entry for every Honeycomb traces.
     - `honeycombio/opentelemetry-web: Honeycomb link: https://ui.honeycomb.io/...`
-- Refer to the sample on [GitHub](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/sample).
+- Refer to the sample on [GitHub](https://github.com/workleap/wl-honeycomb-web/tree/main/sample).

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -16,4 +16,4 @@ order: 100
 
 | Name | Description | NPM | { .packages-table }
 | --- | --- | --- |
-| :icon-mark-github: [@workleap/honeycomb](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/lib) | Default Honeycomb instrumentation for Workleap web applications. | [![npm version](https://img.shields.io/npm/v/@workleap/honeycomb)](https://www.npmjs.com/package/@workleap/honeycomb) |
+| :icon-mark-github: [@workleap/honeycomb](https://github.com/workleap/wl-honeycomb-web/tree/main/lib) | Default Honeycomb instrumentation for Workleap web applications. | [![npm version](https://img.shields.io/npm/v/@workleap/honeycomb)](https://www.npmjs.com/package/@workleap/honeycomb) |

--- a/docs/reference/registerHoneycombInstrumentation.md
+++ b/docs/reference/registerHoneycombInstrumentation.md
@@ -31,7 +31,7 @@ The `registerHoneycombInstrumentation` function registers the following OpenTele
 - [@opentelemetry/instrumentation-fetch](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch)
 - [@opentelemetry/instrumentation-document-load](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-document-load)
 
-For more details, refer to the [registerHoneycombInstrumentation.ts](https://github.com/gsoft-inc/wl-honeycomb-web/blob/main/lib/src/registerHoneycombInstrumentation.ts) file on GitHub.
+For more details, refer to the [registerHoneycombInstrumentation.ts](https://github.com/workleap/wl-honeycomb-web/blob/main/lib/src/registerHoneycombInstrumentation.ts) file on GitHub.
 
 ## Customize backend URLs
 
@@ -306,7 +306,7 @@ We do not guarantee that your configuration transformers won't break after an up
 
 The [predefined options](#predefined-options) are useful to quickly customize the default configuration of the [Honeycomb Web SDK](https://docs.honeycomb.io/send-data/javascript-browser/honeycomb-distribution), but only covers a subset of the [options](https://docs.honeycomb.io/send-data/javascript-browser/honeycomb-distribution/#advanced-configuration). If you need full control over the configuration, you can provide configuration transformer functions through the `transformers` option of the `registerHoneycombInstrumentation` function. Remember, **no locked in** :heart::v:.
 
-To view the default configuration of `registerHoneycombInstrumentation`, have a look at the [registerHoneycombInstrumentation.ts](https://github.com/gsoft-inc/wl-honeycomb-web/blob/main/lib/src/registerHoneycombInstrumentation.ts) file on GitHub.
+To view the default configuration of `registerHoneycombInstrumentation`, have a look at the [registerHoneycombInstrumentation.ts](https://github.com/workleap/wl-honeycomb-web/blob/main/lib/src/registerHoneycombInstrumentation.ts) file on GitHub.
 
 ### `transformers`
 

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -7,11 +7,11 @@ icon: command-palette
 
 With an ingestion API key: 
 
-- :icon-mark-github: [Frontend application](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/samples/api-key/app)
-- :icon-mark-github: [Server](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/samples/api-key/express-server)
+- :icon-mark-github: [Frontend application](https://github.com/workleap/wl-honeycomb-web/tree/main/samples/api-key/app)
+- :icon-mark-github: [Server](https://github.com/workleap/wl-honeycomb-web/tree/main/samples/api-key/express-server)
 
 With a proxy:
 
-- :icon-mark-github: [Frontend application](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/samples/proxy/app)
-- :icon-mark-github: [Proxy](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/samples/proxy/express-proxy)
-- :icon-mark-github: [Server](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/samples/proxy/express-server)
+- :icon-mark-github: [Frontend application](https://github.com/workleap/wl-honeycomb-web/tree/main/samples/proxy/app)
+- :icon-mark-github: [Proxy](https://github.com/workleap/wl-honeycomb-web/tree/main/samples/proxy/express-proxy)
+- :icon-mark-github: [Server](https://github.com/workleap/wl-honeycomb-web/tree/main/samples/proxy/express-server)

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -4,22 +4,22 @@
 
 ### Patch Changes
 
-- [#15](https://github.com/gsoft-inc/wl-honeycomb-web/pull/15) [`bd6ef55`](https://github.com/gsoft-inc/wl-honeycomb-web/commit/bd6ef555cb2f117e02a7f86704ee2fd7d0af6be0) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Default options are now applied to the XML HTTP Request instrumentation as well.
+- [#15](https://github.com/workleap/wl-honeycomb-web/pull/15) [`bd6ef55`](https://github.com/workleap/wl-honeycomb-web/commit/bd6ef555cb2f117e02a7f86704ee2fd7d0af6be0) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Default options are now applied to the XML HTTP Request instrumentation as well.
 
 ## 2.0.0
 
 ### Major Changes
 
-- [#13](https://github.com/gsoft-inc/wl-honeycomb-web/pull/13) [`23c0db1`](https://github.com/gsoft-inc/wl-honeycomb-web/commit/23c0db1a51b1cc16eb3463d7a01a33db1f285ce2) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Rename the `endpoint` option for `proxy`.
+- [#13](https://github.com/workleap/wl-honeycomb-web/pull/13) [`23c0db1`](https://github.com/workleap/wl-honeycomb-web/commit/23c0db1a51b1cc16eb3463d7a01a33db1f285ce2) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Rename the `endpoint` option for `proxy`.
 
 ## 1.0.1
 
 ### Patch Changes
 
-- [#7](https://github.com/gsoft-inc/wl-honeycomb-web/pull/7) [`d2c7deb`](https://github.com/gsoft-inc/wl-honeycomb-web/commit/d2c7deb257b1cdb0cf43d8d791f87b5817024dbc) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added source code and source maps to the package.
+- [#7](https://github.com/workleap/wl-honeycomb-web/pull/7) [`d2c7deb`](https://github.com/workleap/wl-honeycomb-web/commit/d2c7deb257b1cdb0cf43d8d791f87b5817024dbc) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added source code and source maps to the package.
 
 ## 1.0.0
 
 ### Major Changes
 
-- [#2](https://github.com/gsoft-inc/wl-honeycomb-web/pull/2) [`4af1451`](https://github.com/gsoft-inc/wl-honeycomb-web/commit/4af145152fcefa651ef44df13013b77d7157caca) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Initial release.
+- [#2](https://github.com/workleap/wl-honeycomb-web/pull/2) [`4af1451`](https://github.com/workleap/wl-honeycomb-web/commit/4af145152fcefa651ef44df13013b77d7157caca) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Initial release.

--- a/lib/README.md
+++ b/lib/README.md
@@ -10,4 +10,4 @@ View the [contributor's documentation](../../CONTRIBUTING.md).
 
 ## License
 
-Copyright © 2024, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/workleap-license/blob/master/LICENSE.
+Copyright © 2024, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/workleap-license/blob/master/LICENSE.

--- a/lib/README.md
+++ b/lib/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-View the [user's documentation](https://gsoft-inc.github.io/wl-honeycomb-web/).
+View the [user's documentation](https://workleap.github.io/wl-honeycomb-web/).
 
 ## 🤝 Contributing
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-honeycomb-web.git",
+        "url": "git+https://github.com/workleap/wl-honeycomb-web.git",
         "directory": "lib"
     },
     "type": "module",

--- a/retype.yml
+++ b/retype.yml
@@ -16,7 +16,7 @@ toc:
     depth: 2
 
 hub:
-    link: https://gsoft-inc.github.io/wl-idp-docs-hub/
+    link: https://workleap.github.io/wl-idp-docs-hub/
     alt: Workleap's IDP homepage
 
 start:
@@ -29,7 +29,7 @@ start:
 input: ./docs
 output: .retype
 
-url: https://gsoft-inc.github.io/wl-honeycomb-web/
+url: https://workleap.github.io/wl-honeycomb-web/
 
 branding:
     title: "Honeycomb"

--- a/retype.yml
+++ b/retype.yml
@@ -38,7 +38,7 @@ branding:
 favicon: ./static/favicon.png
 
 edit:
-    repo: "https://github.com/gsoft-inc/wl-honeycomb-web"
+    repo: "https://github.com/workleap/wl-honeycomb-web"
     base: /docs
     branch: main
 
@@ -49,22 +49,22 @@ links:
 
     - text: Found a bug?
       icon: issue-opened
-      link: https://github.com/gsoft-inc/wl-honeycomb-web/issues
+      link: https://github.com/workleap/wl-honeycomb-web/issues
       target: blank
 
     - text: Feature requests
       icon: comment-discussion
-      link: https://github.com/gsoft-inc/wl-honeycomb-web/discussions
+      link: https://github.com/workleap/wl-honeycomb-web/discussions
       target: blank
 
     - text: Releases
       icon: tag
-      link: https://github.com/gsoft-inc/wl-honeycomb-web/releases
+      link: https://github.com/workleap/wl-honeycomb-web/releases
       target: blank
 
     - text: Github
       icon: mark-github
-      link: https://github.com/gsoft-inc/wl-honeycomb-web
+      link: https://github.com/workleap/wl-honeycomb-web
       target: blank
 
     - text: NPM
@@ -81,7 +81,7 @@ footer:
 
         - text: License
           icon: shield-check
-          link: https://github.com/gsoft-inc/wl-honeycomb-web/blob/main/LICENSE
+          link: https://github.com/workleap/wl-honeycomb-web/blob/main/LICENSE
           target: blank
 
 # To allow using {{ }} in code blocks.


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 